### PR TITLE
Fix context management and memory item usage

### DIFF
--- a/cognition/Actor/actor.py
+++ b/cognition/Actor/actor.py
@@ -58,12 +58,17 @@ class Actor:
         """Adds an interpreted stimulus to the history."""
         self.interpreted_stimuli_history.append(stimulus)
 
-    def add_to_memory(self, item: str):
+    def add_to_memory(self, item: MemoryItem | InterpretedStimulus | str):
         """
         Creates a MemoryItem from an InterpretedStimulus or string and adds it to
         the list of memorized items.
         """
-        memory_item = MemoryItem(content=item)
+        # If the caller already passed a MemoryItem we can store it directly;
+        # otherwise wrap the provided object so memory entries remain uniform.
+        if isinstance(item, MemoryItem):
+            memory_item = item
+        else:
+            memory_item = MemoryItem(content=item)
         self.memorized_items.append(memory_item)
 
     def __repr__(self) -> str:

--- a/cognition/clients/decision_client.py
+++ b/cognition/clients/decision_client.py
@@ -166,6 +166,9 @@ class DecisionClient:
 
     def __enter__(self):
         """Enter the runtime context related to this object."""
+        # Ensure the BaseClient performs any setup it requires.
+        if hasattr(self.base_client, "__enter__"):
+            self.base_client.__enter__()
         return self
 
     def __exit__(
@@ -175,7 +178,12 @@ class DecisionClient:
         exc_tb: Optional[Any],  # Using Any for traceback type for simplicity
     ):
         """Exit the runtime context related to this object."""
-        pass
+        # Delegate teardown to the BaseClient to ensure resources are released.
+        if hasattr(self.base_client, "__exit__"):
+            self.base_client.__exit__(exc_type, exc_val, exc_tb)
+        else:
+            if hasattr(self.base_client, "close"):
+                self.base_client.close()
 
 
 # Example placeholder for Action type (would likely be in DecisionEngine.types)


### PR DESCRIPTION
## Summary
- propagate context entry/exit from `StimulusClient` and `DecisionClient` to the underlying `BaseClient`
- allow `Actor.add_to_memory` to accept `MemoryItem` or `InterpretedStimulus`

## Testing
- `python -m compileall -q cognition/Actor/actor.py cognition/clients/stimulus_client.py cognition/clients/decision_client.py`
- `python -m compileall -q .`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683fc36ac420833085086f8dd3f175a1