### PR TITLE
Fix context management cleanup

### DIFF
--- a/cognition/clients/decision_client.py
+++ b/cognition/clients/decision_client.py
@@ -166,6 +166,8 @@ class DecisionClient:
 
     def __enter__(self):
         """Enter the runtime context related to this object."""
+        if hasattr(self.base_client, "__enter__"):
+            self.base_client.__enter__()
         return self
 
     def __exit__(
@@ -175,7 +177,11 @@ class DecisionClient:
         exc_tb: Optional[Any],  # Using Any for traceback type for simplicity
     ):
         """Exit the runtime context related to this object."""
-        pass
+        if hasattr(self.base_client, "__exit__"):
+            self.base_client.__exit__(exc_type, exc_val, exc_tb)
+        elif hasattr(self.base_client, "close"):
+            self.base_client.close()
+        return False
 
 
 # Example placeholder for Action type (would likely be in DecisionEngine.types)

--- a/cognition/clients/stimulus_client.py
+++ b/cognition/clients/stimulus_client.py
@@ -217,9 +217,9 @@ class StimulusClient:
 
     def __enter__(self):
         """Enter the runtime context related to this object."""
-        # If BaseClient had significant __enter__ logic, we might call it here:
-        # if hasattr(self.base_client, '__enter__'):
-        #     self.base_client.__enter__()
+        # Delegate context handling to the underlying base_client when possible
+        if hasattr(self.base_client, "__enter__"):
+            self.base_client.__enter__()
         return self
 
     def __exit__(
@@ -231,7 +231,10 @@ class StimulusClient:
         ],  # TracebackType is more specific, but Any is simpler here
     ):
         """Exit the runtime context related to this object."""
-        # If BaseClient had significant __exit__ logic, we might call it here:
-        # if hasattr(self.base_client, '__exit__'):
-        #     self.base_client.__exit__(exc_type, exc_val, exc_tb)
-        pass
+        # Ensure the wrapped BaseClient cleans up its resources
+        if hasattr(self.base_client, "__exit__"):
+            self.base_client.__exit__(exc_type, exc_val, exc_tb)
+        elif hasattr(self.base_client, "close"):
+            self.base_client.close()
+        # Returning False propagates exceptions, matching default context manager behaviour
+        return False


### PR DESCRIPTION
## Summary
- ensure StimulusClient and DecisionClient close the underlying BaseClient
- delegate `__enter__` and `__exit__` calls to the wrapped client so resources are released properly

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_683fc3330bac8330b7ec812694bd00be